### PR TITLE
make php 5.3 compat and add tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .DS_Store
+vendor
+composer.lock

--- a/composer.json
+++ b/composer.json
@@ -1,31 +1,34 @@
 {
-    "name": "illuminate/container",
-    "description": "The Illuminate Container package.",
+    "name": "netrivet/container",
+    "description": "A PHP 5.3 compatible fork of the illuminate/container package.",
     "license": "MIT",
-    "homepage": "http://laravel.com",
-    "support": {
-        "issues": "https://github.com/laravel/framework/issues",
-        "source": "https://github.com/laravel/framework"
-    },
+    "homepage": "https://github.com/netrivet/container",
     "authors": [
         {
             "name": "Taylor Otwell",
             "email": "taylorotwell@gmail.com"
+        },
+        {
+            "name": "Jared Henderson",
+            "email": "jared@netrivet.com"
         }
     ],
     "require": {
-        "php": ">=5.5.9",
-        "illuminate/contracts": "5.2.*"
+        "php": ">=5.3.0"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^4.7",
+        "symfony/var-dumper": "~2.0"
     },
     "autoload": {
         "psr-4": {
-            "Illuminate\\Container\\": ""
+            "NetRivet\\Container\\": "src/"
         }
     },
-    "extra": {
-        "branch-alias": {
-            "dev-master": "5.2-dev"
-        }
-    },
+   "autoload-dev": {
+       "psr-4": {
+           "NetRivet\\Container\\Test\\": "tests/fixtures"
+       }
+   },
     "minimum-stability": "dev"
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,11 @@
+<phpunit bootstrap="vendor/autoload.php"
+         backupGlobals="false"
+         backupStaticAttributes="false"
+         stopOnFailure="true"
+         colors="true">
+    <testsuites>
+        <testsuite name="NetRivet Container Test Suite">
+            <directory suffix=".php">./tests/</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/src/BindingResolutionException.php
+++ b/src/BindingResolutionException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace NetRivet\Container;
+
+class BindingResolutionException extends \Exception
+{
+}

--- a/src/Container.php
+++ b/src/Container.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Illuminate\Container;
+namespace NetRivet\Container;
 
 use Closure;
 use ArrayAccess;
@@ -9,10 +9,8 @@ use ReflectionMethod;
 use ReflectionFunction;
 use ReflectionParameter;
 use InvalidArgumentException;
-use Illuminate\Contracts\Container\BindingResolutionException;
-use Illuminate\Contracts\Container\Container as ContainerContract;
 
-class Container implements ArrayAccess, ContainerContract
+class Container implements ArrayAccess, ContainerInterface
 {
     /**
      * The current globally available container (if any).
@@ -26,97 +24,97 @@ class Container implements ArrayAccess, ContainerContract
      *
      * @var array
      */
-    protected $resolved = [];
+    protected $resolved = array();
 
     /**
      * The container's bindings.
      *
      * @var array
      */
-    protected $bindings = [];
+    protected $bindings = array();
 
     /**
      * The container's shared instances.
      *
      * @var array
      */
-    protected $instances = [];
+    protected $instances = array();
 
     /**
      * The registered type aliases.
      *
      * @var array
      */
-    protected $aliases = [];
+    protected $aliases = array();
 
     /**
      * The extension closures for services.
      *
      * @var array
      */
-    protected $extenders = [];
+    protected $extenders = array();
 
     /**
      * All of the registered tags.
      *
      * @var array
      */
-    protected $tags = [];
+    protected $tags = array();
 
     /**
      * The stack of concretions being current built.
      *
      * @var array
      */
-    protected $buildStack = [];
+    protected $buildStack = array();
 
     /**
      * The contextual binding map.
      *
      * @var array
      */
-    public $contextual = [];
+    public $contextual = array();
 
     /**
      * All of the registered rebound callbacks.
      *
      * @var array
      */
-    protected $reboundCallbacks = [];
+    protected $reboundCallbacks = array();
 
     /**
      * All of the global resolving callbacks.
      *
      * @var array
      */
-    protected $globalResolvingCallbacks = [];
+    protected $globalResolvingCallbacks = array();
 
     /**
      * All of the global after resolving callbacks.
      *
      * @var array
      */
-    protected $globalAfterResolvingCallbacks = [];
+    protected $globalAfterResolvingCallbacks = array();
 
     /**
      * All of the after resolving callbacks by class type.
      *
      * @var array
      */
-    protected $resolvingCallbacks = [];
+    protected $resolvingCallbacks = array();
 
     /**
      * All of the after resolving callbacks by class type.
      *
      * @var array
      */
-    protected $afterResolvingCallbacks = [];
+    protected $afterResolvingCallbacks = array();
 
     /**
      * Define a contextual binding.
      *
      * @param  string  $concrete
-     * @return \Illuminate\Contracts\Container\ContextualBindingBuilder
+     * @return \NetRivet\Container\ContextualBindingBuilder
      */
     public function when($concrete)
     {
@@ -210,7 +208,7 @@ class Container implements ArrayAccess, ContainerContract
      */
     protected function getClosure($abstract, $concrete)
     {
-        return function ($c, $parameters = []) use ($abstract, $concrete) {
+        return function ($c, $parameters = array()) use ($abstract, $concrete) {
             $method = ($abstract == $concrete) ? 'build' : 'make';
 
             return $c->$method($concrete, $parameters);
@@ -343,7 +341,7 @@ class Container implements ArrayAccess, ContainerContract
 
         foreach ($tags as $tag) {
             if (!isset($this->tags[$tag])) {
-                $this->tags[$tag] = [];
+                $this->tags[$tag] = array();
             }
 
             foreach ((array) $abstracts as $abstract) {
@@ -360,7 +358,7 @@ class Container implements ArrayAccess, ContainerContract
      */
     public function tagged($tag)
     {
-        $results = [];
+        $results = array();
 
         if (isset($this->tags[$tag])) {
             foreach ($this->tags[$tag] as $abstract) {
@@ -391,7 +389,7 @@ class Container implements ArrayAccess, ContainerContract
      */
     protected function extractAlias(array $definition)
     {
-        return [key($definition), current($definition)];
+        return array(key($definition), current($definition));
     }
 
     /**
@@ -452,7 +450,7 @@ class Container implements ArrayAccess, ContainerContract
             return $this->reboundCallbacks[$abstract];
         }
 
-        return [];
+        return array();
     }
 
     /**
@@ -462,7 +460,7 @@ class Container implements ArrayAccess, ContainerContract
      * @param  array  $parameters
      * @return \Closure
      */
-    public function wrap(Closure $callback, array $parameters = [])
+    public function wrap(Closure $callback, array $parameters = array())
     {
         return function () use ($callback, $parameters) {
             return $this->call($callback, $parameters);
@@ -477,7 +475,7 @@ class Container implements ArrayAccess, ContainerContract
      * @param  string|null  $defaultMethod
      * @return mixed
      */
-    public function call($callback, array $parameters = [], $defaultMethod = null)
+    public function call($callback, array $parameters = array(), $defaultMethod = null)
     {
         if ($this->isCallableWithAtSign($callback) || $defaultMethod) {
             return $this->callClass($callback, $parameters, $defaultMethod);
@@ -510,9 +508,9 @@ class Container implements ArrayAccess, ContainerContract
      * @param  array  $parameters
      * @return array
      */
-    protected function getMethodDependencies($callback, array $parameters = [])
+    protected function getMethodDependencies($callback, array $parameters = array())
     {
-        $dependencies = [];
+        $dependencies = array();
 
         foreach ($this->getCallReflector($callback)->getParameters() as $key => $parameter) {
             $this->addDependencyForCallParameter($parameter, $parameters, $dependencies);
@@ -569,7 +567,7 @@ class Container implements ArrayAccess, ContainerContract
      * @param  string|null  $defaultMethod
      * @return mixed
      */
-    protected function callClass($target, array $parameters = [], $defaultMethod = null)
+    protected function callClass($target, array $parameters = array(), $defaultMethod = null)
     {
         $segments = explode('@', $target);
 
@@ -582,7 +580,7 @@ class Container implements ArrayAccess, ContainerContract
             throw new InvalidArgumentException('Method not provided.');
         }
 
-        return $this->call([$this->make($segments[0]), $method], $parameters);
+        return $this->call(array($this->make($segments[0]), $method), $parameters);
     }
 
     /**
@@ -592,7 +590,7 @@ class Container implements ArrayAccess, ContainerContract
      * @param  array   $parameters
      * @return mixed
      */
-    public function make($abstract, array $parameters = [])
+    public function make($abstract, array $parameters = array())
     {
         $abstract = $this->getAlias($abstract);
 
@@ -698,7 +696,7 @@ class Container implements ArrayAccess, ContainerContract
             return $this->extenders[$abstract];
         }
 
-        return [];
+        return array();
     }
 
     /**
@@ -708,9 +706,9 @@ class Container implements ArrayAccess, ContainerContract
      * @param  array   $parameters
      * @return mixed
      *
-     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     * @throws \NetRivet\Container\BindingResolutionException
      */
-    public function build($concrete, array $parameters = [])
+    public function build($concrete, array $parameters = array())
     {
         // If the concrete type is actually a Closure, we will just execute it and
         // hand back the results of the functions, which allows functions to be
@@ -768,9 +766,9 @@ class Container implements ArrayAccess, ContainerContract
      * @param  array  $primitives
      * @return array
      */
-    protected function getDependencies(array $parameters, array $primitives = [])
+    protected function getDependencies(array $parameters, array $primitives = array())
     {
-        $dependencies = [];
+        $dependencies = array();
 
         foreach ($parameters as $parameter) {
             $dependency = $parameter->getClass();
@@ -796,7 +794,7 @@ class Container implements ArrayAccess, ContainerContract
      * @param  \ReflectionParameter  $parameter
      * @return mixed
      *
-     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     * @throws \NetRivet\Container\BindingResolutionException
      */
     protected function resolveNonClass(ReflectionParameter $parameter)
     {
@@ -815,7 +813,7 @@ class Container implements ArrayAccess, ContainerContract
      * @param  \ReflectionParameter  $parameter
      * @return mixed
      *
-     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     * @throws \NetRivet\Container\BindingResolutionException
      */
     protected function resolveClass(ReflectionParameter $parameter)
     {
@@ -935,7 +933,8 @@ class Container implements ArrayAccess, ContainerContract
             return;
         }
 
-        $expected = $function->getParameters()[0];
+        $parameters = $function->getParameters();
+        $expected = $parameters[0];
 
         if (!$expected->getClass()) {
             return;
@@ -981,7 +980,7 @@ class Container implements ArrayAccess, ContainerContract
      */
     protected function getCallbacksForType($abstract, $object, array $callbacksPerType)
     {
-        $results = [];
+        $results = array();
 
         foreach ($callbacksPerType as $type => $callbacks) {
             if ($type === $abstract || $object instanceof $type) {
@@ -1084,7 +1083,7 @@ class Container implements ArrayAccess, ContainerContract
      */
     public function forgetInstances()
     {
-        $this->instances = [];
+        $this->instances = array();
     }
 
     /**
@@ -1094,10 +1093,10 @@ class Container implements ArrayAccess, ContainerContract
      */
     public function flush()
     {
-        $this->aliases = [];
-        $this->resolved = [];
-        $this->bindings = [];
-        $this->instances = [];
+        $this->aliases = array();
+        $this->resolved = array();
+        $this->bindings = array();
+        $this->instances = array();
     }
 
     /**
@@ -1113,10 +1112,10 @@ class Container implements ArrayAccess, ContainerContract
     /**
      * Set the shared instance of the container.
      *
-     * @param  \Illuminate\Contracts\Container\Container  $container
+     * @param  \NetRivet\Container\ContainerInterface  $container
      * @return void
      */
-    public static function setInstance(ContainerContract $container)
+    public static function setInstance(ContainerInterface $container)
     {
         static::$instance = $container;
     }

--- a/src/ContainerInterface.php
+++ b/src/ContainerInterface.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace NetRivet\Container;
+
+use Closure;
+
+interface ContainerInterface
+{
+    /**
+     * Determine if the given abstract type has been bound.
+     *
+     * @param  string  $abstract
+     * @return bool
+     */
+    public function bound($abstract);
+
+    /**
+     * Alias a type to a different name.
+     *
+     * @param  string  $abstract
+     * @param  string  $alias
+     * @return void
+     */
+    public function alias($abstract, $alias);
+
+    /**
+     * Assign a set of tags to a given binding.
+     *
+     * @param  array|string  $abstracts
+     * @param  array|mixed   ...$tags
+     * @return void
+     */
+    public function tag($abstracts, $tags);
+
+    /**
+     * Resolve all of the bindings for a given tag.
+     *
+     * @param  array  $tag
+     * @return array
+     */
+    public function tagged($tag);
+
+    /**
+     * Register a binding with the container.
+     *
+     * @param  string|array  $abstract
+     * @param  \Closure|string|null  $concrete
+     * @param  bool  $shared
+     * @return void
+     */
+    public function bind($abstract, $concrete = null, $shared = false);
+
+    /**
+     * Register a binding if it hasn't already been registered.
+     *
+     * @param  string  $abstract
+     * @param  \Closure|string|null  $concrete
+     * @param  bool  $shared
+     * @return void
+     */
+    public function bindIf($abstract, $concrete = null, $shared = false);
+
+    /**
+     * Register a shared binding in the container.
+     *
+     * @param  string  $abstract
+     * @param  \Closure|string|null  $concrete
+     * @return void
+     */
+    public function singleton($abstract, $concrete = null);
+
+    /**
+     * "Extend" an abstract type in the container.
+     *
+     * @param  string    $abstract
+     * @param  \Closure  $closure
+     * @return void
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function extend($abstract, Closure $closure);
+
+    /**
+     * Register an existing instance as shared in the container.
+     *
+     * @param  string  $abstract
+     * @param  mixed   $instance
+     * @return void
+     */
+    public function instance($abstract, $instance);
+
+    /**
+     * Define a contextual binding.
+     *
+     * @param  string  $concrete
+     * @return \NetRivet\Container\ContextualBindingBuilderInterface
+     */
+    public function when($concrete);
+
+    /**
+     * Resolve the given type from the container.
+     *
+     * @param  string  $abstract
+     * @param  array   $parameters
+     * @return mixed
+     */
+    public function make($abstract, array $parameters = array());
+
+    /**
+     * Call the given Closure / class@method and inject its dependencies.
+     *
+     * @param  callable|string  $callback
+     * @param  array  $parameters
+     * @param  string|null  $defaultMethod
+     * @return mixed
+     */
+    public function call($callback, array $parameters = array(), $defaultMethod = null);
+
+    /**
+     * Determine if the given abstract type has been resolved.
+     *
+     * @param  string $abstract
+     * @return bool
+     */
+    public function resolved($abstract);
+
+    /**
+     * Register a new resolving callback.
+     *
+     * @param  string    $abstract
+     * @param  \Closure|null  $callback
+     * @return void
+     */
+    public function resolving($abstract, Closure $callback = null);
+
+    /**
+     * Register a new after resolving callback.
+     *
+     * @param  string    $abstract
+     * @param  \Closure|null  $callback
+     * @return void
+     */
+    public function afterResolving($abstract, Closure $callback = null);
+}

--- a/src/ContextualBindingBuilder.php
+++ b/src/ContextualBindingBuilder.php
@@ -1,15 +1,13 @@
 <?php
 
-namespace Illuminate\Container;
+namespace NetRivet\Container;
 
-use Illuminate\Contracts\Container\ContextualBindingBuilder as ContextualBindingBuilderContract;
-
-class ContextualBindingBuilder implements ContextualBindingBuilderContract
+class ContextualBindingBuilder implements ContextualBindingBuilderInterface
 {
     /**
      * The underlying container instance.
      *
-     * @var \Illuminate\Container\Container
+     * @var \NetRivet\Container\ContainerInterface
      */
     protected $container;
 
@@ -30,11 +28,11 @@ class ContextualBindingBuilder implements ContextualBindingBuilderContract
     /**
      * Create a new contextual binding builder.
      *
-     * @param  \Illuminate\Container\Container  $container
+     * @param  \NetRivet\Container\ContainerInterface  $container
      * @param  string  $concrete
      * @return void
      */
-    public function __construct(Container $container, $concrete)
+    public function __construct(ContainerInterface $container, $concrete)
     {
         $this->concrete = $concrete;
         $this->container = $container;

--- a/src/ContextualBindingBuilderInterface.php
+++ b/src/ContextualBindingBuilderInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace NetRivet\Container;
+
+interface ContextualBindingBuilderInterface
+{
+    /**
+     * Define the abstract target that depends on the context.
+     *
+     * @param  string  $abstract
+     * @return $this
+     */
+    public function needs($abstract);
+
+    /**
+     * Define the implementation for the contextual binding.
+     *
+     * @param  \Closure|string  $implementation
+     * @return void
+     */
+    public function give($implementation);
+}

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace NetRivet\Container;
+
+class ContainerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Container
+     */
+    protected $container;
+
+
+    public function setUp()
+    {
+        $this->container = new Container();
+    }
+
+
+    public function testCanResolveDependencies()
+    {
+        $qux = $this->container->make('NetRivet\Container\Test\Qux');
+
+        $baz = $qux->getBaz();
+
+        $this->assertInstanceOf('NetRivet\Container\Test\Baz', $baz);
+    }
+
+
+    public function testCanBindInterfaceToImplementationUsingBind()
+    {
+        $this->container->bind('NetRivet\Container\Test\BarInterface', 'NetRivet\Container\Test\Bar1');
+        $foo = $this->container->make('NetRivet\Container\Test\Foo');
+
+        $bar = $foo->getBar();
+
+        $this->assertInstanceOf('NetRivet\Container\Test\Bar1', $bar);
+    }
+
+
+    public function testCanBindInterfaceUsingWhenNeedsGive()
+    {
+        $this->container
+            ->when('NetRivet\Container\Test\Foo')
+            ->needs('NetRivet\Container\Test\BarInterface')
+            ->give('NetRivet\Container\Test\Bar2');
+
+        $foo = $this->container->make('NetRivet\Container\Test\Foo');
+        $bar = $foo->getBar();
+
+        $this->assertInstanceOf('NetRivet\Container\Test\Bar2', $bar);
+    }
+}

--- a/tests/fixtures/Bar1.php
+++ b/tests/fixtures/Bar1.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace NetRivet\Container\Test;
+
+class Bar1 implements BarInterface
+{
+}

--- a/tests/fixtures/Bar2.php
+++ b/tests/fixtures/Bar2.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace NetRivet\Container\Test;
+
+class Bar2 implements BarInterface
+{
+}

--- a/tests/fixtures/BarInterface.php
+++ b/tests/fixtures/BarInterface.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace NetRivet\Container\Test;
+
+interface BarInterface
+{
+}

--- a/tests/fixtures/Baz.php
+++ b/tests/fixtures/Baz.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace NetRivet\Container\Test;
+
+class Baz
+{
+}

--- a/tests/fixtures/Foo.php
+++ b/tests/fixtures/Foo.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace NetRivet\Container\Test;
+
+class Foo
+{
+    public function __construct(BarInterface $bar, Baz $baz)
+    {
+        $this->bar = $bar;
+        $this->baz = $baz;
+    }
+
+    public function getBar()
+    {
+        return $this->bar;
+    }
+
+    public function getBaz()
+    {
+        return $this->baz;
+    }
+}

--- a/tests/fixtures/Qux.php
+++ b/tests/fixtures/Qux.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace NetRivet\Container\Test;
+
+class Qux
+{
+    public function __construct(Baz $baz)
+    {
+        $this->baz = $baz;
+    }
+
+    public function getBaz()
+    {
+        return $this->baz;
+    }
+}


### PR DESCRIPTION
This PR represents the basic task of PHP 5.3-ifying `illuminate/container`.  I pushed the unmodified source files first to netrivet/master so that you could see the diffs between the files.

I ended up copying over and modifying the interfaces from `illuminate/contracts` instead of making that a dependency, because that's a pretty big package just to get two interfaces and one exception. Doing it this way makes this package have no non-dev dependencies.  But if you guys think I should composer require the actual contracts from illuminate, I'm open for discussion.

Also, added some basic unit tests. Travis will be running on 5.3 so that should give us some basic confidence that this works. :dancers:
