### PR TITLE
Allow contextually binding primitives

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -798,6 +798,14 @@ class Container implements ArrayAccess, ContainerInterface
      */
     protected function resolveNonClass(ReflectionParameter $parameter)
     {
+        if (! is_null($concrete = $this->getContextualConcrete('$'.$parameter->name))) {
+            if ($concrete instanceof Closure) {
+                return call_user_func($concrete, $this);
+            } else {
+                return $concrete;
+            }
+        }
+
         if ($parameter->isDefaultValueAvailable()) {
             return $parameter->getDefaultValue();
         }


### PR DESCRIPTION
This is a new feature that Laravel Container added since we forked.  It was only a few lines to make work, copied from their newer source, and it allows us to do cool stuff like this:

``` PHP
/**
 * NotificationRepository
 */
$container
    ->when('ProPhoto\Infrastructure\WordPress\User\NotificationRepository')
    ->needs('$config')
    ->give(function() {
        return require(TEMPLATEPATH . '/config/conf.notifications.php');
    });
```

See https://laravel.com/docs/5.3/container
